### PR TITLE
Added optional command line argument to set cycle-rate of CPU-loop

### DIFF
--- a/include/Machine.hpp
+++ b/include/Machine.hpp
@@ -26,6 +26,7 @@ private:
 	Keyboard kb; // presents Keyboard related functions
 	uint16_t PC; // Program Counter
 	std::chrono::steady_clock::time_point last_tick;
+	uint16_t cycleRate; // Argument that can be added to set the cycle-rate of the emulator
 	
 	// Methods
 	void execute(uint16_t& opcode);
@@ -36,4 +37,6 @@ public:
 	Machine();
 	void setInst(std::vector<uint8_t>& prog, uint16_t start_addr);
 	void runLoop();
+	void setCycleRate(uint16_t rate);
+	uint16_t getCycleRate();
 };

--- a/include/Machine.hpp
+++ b/include/Machine.hpp
@@ -26,7 +26,7 @@ private:
 	Keyboard kb; // presents Keyboard related functions
 	uint16_t PC; // Program Counter
 	std::chrono::steady_clock::time_point last_tick;
-	uint16_t cycleRate; // Argument that can be added to set the cycle-rate of the emulator
+	uint16_t cpu_sleep_period; // Argument that can be added to set the cycle-rate of the emulator
 	
 	// Methods
 	void execute(uint16_t& opcode);
@@ -38,5 +38,4 @@ public:
 	void setInst(std::vector<uint8_t>& prog, uint16_t start_addr);
 	void runLoop();
 	void setCycleRate(uint16_t rate);
-	uint16_t getCycleRate();
 };

--- a/src/Machine.cpp
+++ b/src/Machine.cpp
@@ -16,6 +16,7 @@ Machine::Machine(){
 	SP = 0;
 	DT = 0;
 	ST = 0;
+	cpu_sleep_period = 10;
 }
 
 uint8_t Machine::random_byte(){
@@ -179,11 +180,7 @@ void Machine::print_machine_state(){
 }
 
 void Machine::setCycleRate(uint16_t rate){
-	cycleRate = rate;
-}
-
-uint16_t Machine::getCycleRate(){
-	return(cycleRate);
+	cpu_sleep_period = rate;
 }
 
 void Machine::runLoop(){
@@ -205,6 +202,6 @@ void Machine::runLoop(){
 
 		// Update timers
 		update_timers(std::chrono::steady_clock::now());
-		std::this_thread::sleep_for(std::chrono::microseconds(getCycleRate()));
+		std::this_thread::sleep_for(std::chrono::microseconds(cpu_sleep_period));
 	}
 }

--- a/src/Machine.cpp
+++ b/src/Machine.cpp
@@ -178,6 +178,14 @@ void Machine::print_machine_state(){
 	std::cout << "\n";
 }
 
+void Machine::setCycleRate(uint16_t rate){
+	cycleRate = rate;
+}
+
+uint16_t Machine::getCycleRate(){
+	return(cycleRate);
+}
+
 void Machine::runLoop(){
 	while(true){
 		// Update display
@@ -197,7 +205,6 @@ void Machine::runLoop(){
 
 		// Update timers
 		update_timers(std::chrono::steady_clock::now());
-
-		std::this_thread::sleep_for(std::chrono::microseconds(10));
+		std::this_thread::sleep_for(std::chrono::microseconds(getCycleRate()));
 	}
 }

--- a/src/c8emu.cpp
+++ b/src/c8emu.cpp
@@ -28,6 +28,14 @@ int main(int argc, char ** argv){
 		// Load Sprites
 		loadFile("res/sprites.bin", prog);
 		machine.setInst(prog, 0x000);
+		
+		// Set Machine cycle-rate
+		if(argc==3){
+			machine.setCycleRate((uint16_t)strtol(argv[2],NULL,10));
+		}
+		else{
+			machine.setCycleRate(10);
+		}
 	}
 	
 	// Begin instruction fetch-execute-increment cycle

--- a/src/c8emu.cpp
+++ b/src/c8emu.cpp
@@ -33,9 +33,6 @@ int main(int argc, char ** argv){
 		if(argc==3){
 			machine.setCycleRate((uint16_t)strtol(argv[2],NULL,10));
 		}
-		else{
-			machine.setCycleRate(10);
-		}
 	}
 	
 	// Begin instruction fetch-execute-increment cycle


### PR DESCRIPTION
Provided the `cycleRate` attribute to the Machine class. An optional argument can be passed to the emulator in microseconds to control the CPU loop rate, which is otherwise set to 10 by default.

Example to set cycle rate to 5000 microseconds:
```
./bin/c8emu ./roms/games/Tetris\ \[Fran\ Dachille\,\ 1991\].ch8 5000
```

Closes #2  